### PR TITLE
mention 'Masonry' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pro Gallery Layouter ([DEMO](https://wix-incubator.github.io/pro-gallery-layouter/))
 [![Build Status](https://travis-ci.org/wix-incubator/pro-gallery-layouter.svg?branch=master)](https://travis-ci.org/wix-incubator/pro-gallery-layouter)
 
-This module creates a layout from a list of items, each containing an id, width and height. The layout is fitted to a specified container and is adjusted by a set of style params. It also handles viewport visibility to render only the items in the viewport.
+This module creates a Masonry layout from a list of items, each containing an id, width and height. The layout is fitted to a specified container and is adjusted by a set of style params. It also handles viewport visibility to render only the items in the viewport.
 
 - [Getting started](#getting-started)
 - [API](#api)


### PR DESCRIPTION
'Masonry layout' is more precise to what you're creating, vs a manual-layout which I first assumed you had here.
https://medium.com/@andybarefoot/a-masonry-style-layout-using-css-grid-8c663d355ebb

I also suggest changing your description to "Create stunning Masonry layouts in a flash "